### PR TITLE
Fix Vulnerability 2

### DIFF
--- a/webwolf/src/main/java/org/owasp/webwolf/WebSecurityConfig.java
+++ b/webwolf/src/main/java/org/owasp/webwolf/WebSecurityConfig.java
@@ -35,7 +35,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
-
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 /**
  * Security configuration for WebGoat.
  */
@@ -67,7 +67,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Autowired
     public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(userDetailsService); //.passwordEncoder(bCryptPasswordEncoder());
+        auth.userDetailsService(userDetailsService).passwordEncoder(new BCryptPasswordEncoder());
     }
 
     @Bean


### PR DESCRIPTION
Fixed same vulnerability as before, but in other package.
Descrition of vulnerability:
Storing users' passwords in clear-text in a database is definitely not safe as hackers may have read access to all user accounts stored in the database. It's common then to hash passwords and only store these hashes in the database. When running the authentication process, the hash of the password provided by the user is compared to the hash stored in the database. If both matches, the access is granted. 
Solition is resolved by using:
org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder